### PR TITLE
Update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/weekly-analytics-report.yml
+++ b/.github/workflows/weekly-analytics-report.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip


### PR DESCRIPTION
Updates checkout and setup-python to their current major versions so the weekly report no longer emits the Node.js 20 deprecation warning.